### PR TITLE
[WIP] Improved media modal

### DIFF
--- a/app/javascript/mastodon/components/extended_video_player.js
+++ b/app/javascript/mastodon/components/extended_video_player.js
@@ -11,6 +11,7 @@ export default class ExtendedVideoPlayer extends React.PureComponent {
     time: PropTypes.number,
     controls: PropTypes.bool.isRequired,
     muted: PropTypes.bool.isRequired,
+    onClick: PropTypes.func,
   };
 
   handleLoadedData = () => {
@@ -31,6 +32,12 @@ export default class ExtendedVideoPlayer extends React.PureComponent {
     this.video = c;
   }
 
+  handleClick = ev => {
+    ev.stopPropagation();
+    const handler = this.props.onClick;
+    if (handler) handler();
+  }
+
   render () {
     const { src, muted, controls, alt } = this.props;
 
@@ -46,6 +53,7 @@ export default class ExtendedVideoPlayer extends React.PureComponent {
           muted={muted}
           controls={controls}
           loop={!controls}
+          onClick={this.handleClick}
         />
       </div>
     );

--- a/app/javascript/mastodon/components/extended_video_player.js
+++ b/app/javascript/mastodon/components/extended_video_player.js
@@ -32,8 +32,8 @@ export default class ExtendedVideoPlayer extends React.PureComponent {
     this.video = c;
   }
 
-  handleClick = ev => {
-    ev.stopPropagation();
+  handleClick = e => {
+    e.stopPropagation();
     const handler = this.props.onClick;
     if (handler) handler();
   }

--- a/app/javascript/mastodon/features/ui/components/image_loader.js
+++ b/app/javascript/mastodon/features/ui/components/image_loader.js
@@ -120,6 +120,10 @@ export default class ImageLoader extends React.PureComponent {
     return typeof width === 'number' && typeof height === 'number';
   }
 
+  setCanvasRef = c => {
+    this.canvas = c;
+  }
+
   render () {
     const { alt, src, width, height, onClick } = this.props;
     const { loading } = this.state;
@@ -129,16 +133,12 @@ export default class ImageLoader extends React.PureComponent {
       'image-loader--amorphous': !this.hasSize(),
     });
 
-    const setCanvasRef = c => {
-      this.canvas = c;
-    };
-
     return (
       <div className={className}>
         {loading ? (
           <canvas
             className='image-loader__preview-canvas'
-            ref={setCanvasRef}
+            ref={this.setCanvasRef}
             width={width}
             height={height}
           />

--- a/app/javascript/mastodon/features/ui/components/image_loader.js
+++ b/app/javascript/mastodon/features/ui/components/image_loader.js
@@ -2,6 +2,21 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
+const MIN_SCALE = 1;
+const MAX_SCALE = 4;
+const DOUBLE_TAP_SCALE = 2;
+const DOUBLE_TAP_THRESHOLD = 300; // ms
+
+const getMidpoint = (p1, p2) => ({
+  x: (p1.clientX + p2.clientX) / 2,
+  y: (p1.clientY + p2.clientY) / 2,
+});
+
+const getDistance = (p1, p2) =>
+  Math.sqrt(Math.pow(p1.clientX - p2.clientX, 2) + Math.pow(p1.clientY - p2.clientY, 2));
+
+const between = (min, max, value) => Math.min(max, Math.max(min, value));
+
 export default class ImageLoader extends React.PureComponent {
 
   static propTypes = {
@@ -10,6 +25,8 @@ export default class ImageLoader extends React.PureComponent {
     previewSrc: PropTypes.string,
     width: PropTypes.number,
     height: PropTypes.number,
+    onClick: PropTypes.func,
+    onScroll: PropTypes.func,
   }
 
   static defaultProps = {
@@ -21,9 +38,15 @@ export default class ImageLoader extends React.PureComponent {
   state = {
     loading: true,
     error: false,
+    scale: MIN_SCALE,
   }
 
   removers = [];
+  container = null;
+  canvas = null;
+  image = null;
+  lastTouchEndTime = 0;
+  lastDistance = 0;
 
   get canvasContext() {
     if (!this.canvas) {
@@ -34,6 +57,13 @@ export default class ImageLoader extends React.PureComponent {
   }
 
   componentDidMount () {
+    // TODO register to removers
+    this.container.addEventListener('touchstart', this.handleTouchStart.bind(this));
+    // on Chrome 56+, touch event listeners will default to passive
+    // https://www.chromestatus.com/features/5093566007214080
+    this.container.addEventListener('touchmove', this.handleTouchMove.bind(this), { passive: false });
+    this.container.addEventListener('touchend', this.handleTouchEnd.bind(this));
+
     this.loadImage(this.props);
   }
 
@@ -41,6 +71,10 @@ export default class ImageLoader extends React.PureComponent {
     if (this.props.src !== nextProps.src) {
       this.loadImage(nextProps);
     }
+  }
+
+  componentWillUnmount () {
+    this.removeEventListeners();
   }
 
   loadImage (props) {
@@ -113,36 +147,138 @@ export default class ImageLoader extends React.PureComponent {
     return typeof width === 'number' && typeof height === 'number';
   }
 
-  setCanvasRef = c => {
-    this.canvas = c;
+  handleTouchStart = ev => {
+    if (ev.touches.length !== 2) return;
+
+    this.lastDistance = getDistance(...ev.touches);
+  }
+
+  handleTouchMove = ev => {
+    const { scrollTop, scrollHeight, clientHeight } = this.container;
+    if (ev.touches.length === 1
+      && scrollTop !== scrollHeight - clientHeight) {
+      // prevent propagating event to MediaModal
+      ev.stopPropagation();
+      return;
+    }
+    if (ev.touches.length !== 2) return;
+
+    ev.preventDefault();
+    ev.stopPropagation();
+
+    const distance = getDistance(...ev.touches);
+    const midpoint = getMidpoint(...ev.touches);
+    const scale = between(MIN_SCALE, MAX_SCALE, this.state.scale * distance / this.lastDistance);
+
+    this.zoom(scale, midpoint);
+
+    this.lastMidpoint = midpoint;
+    this.lastDistance = distance;
+  }
+
+  handleTouchEnd = ev => {
+    if (ev.touches.length > 0) return;
+    if (this.lastTouchEndTime && ev.timeStamp < this.lastTouchEndTime + DOUBLE_TAP_THRESHOLD) {
+      ev.preventDefault();
+      this.handleDoubleTap(ev);
+    }
+
+    this.lastTouchEndTime = ev.timeStamp;
+  }
+
+  handleScroll = ev => {
+    const handler = this.props.onScroll;
+    if (handler) handler(ev);
+  }
+
+  handleDoubleTap (ev) {
+    if (this.state.scale === MIN_SCALE)
+      this.zoom(DOUBLE_TAP_SCALE, { x: ev.clientX, y: ev.clientY });
+    else
+      this.zoom(MIN_SCALE, { x: ev.clientX, y: ev.clientY });
+  }
+
+  zoom(nextScale, midpoint) {
+    const { scale } = this.state;
+    const { scrollLeft, scrollTop } = this.container;
+
+    // math memo:
+    // x = (scrollLeft + midpoint.x) / scrollWidth
+    // x' = (nextScrollLeft + midpoint.x) / nextScrollWidth
+    // scrollWidth = clientWidth * scale
+    // scrollWidth' = clientWidth * nextScale
+    // Solve x = x' for nextScrollLeft
+    const nextScrollLeft = (scrollLeft + midpoint.x) * nextScale / scale - midpoint.x;
+    const nextScrollTop = (scrollTop + midpoint.y) * nextScale / scale - midpoint.y;
+
+    // this.container.scrollLeft = nextScrollLeft;
+    // this.container.scrollTop = nextScrollTop;
+
+    this.setState({ scale: nextScale }, () => {
+      // callback
+      this.container.scrollLeft = nextScrollLeft;
+      this.container.scrollTop = nextScrollTop;
+    });
+  }
+
+  handleClick = ev => {
+    // don't propagate event to MediaModal
+    ev.stopPropagation();
+    const handler = this.props.onClick;
+    if (handler) handler();
   }
 
   render () {
     const { alt, src, width, height } = this.props;
-    const { loading } = this.state;
+    const { loading, scale } = this.state;
+    const overflow = scale === 1 ? 'hidden' : 'scroll';
 
     const className = classNames('image-loader', {
       'image-loader--loading': loading,
       'image-loader--amorphous': !this.hasSize(),
     });
 
-    return (
-      <div className={className}>
-        <canvas
-          className='image-loader__preview-canvas'
-          width={width}
-          height={height}
-          ref={this.setCanvasRef}
-          style={{ opacity: loading ? 1 : 0 }}
-        />
+    const setContainerRef = c => {
+      this.container = c;
+    };
+    const setCanvasRef = c => {
+      this.canvas = c;
+    };
+    const setImageRef = c => {
+      this.image = c;
+    };
 
+    return (
+      <div
+        className={className}
+        ref={setContainerRef}
+        style={{
+          height: `${document.body.clientHeight}px`,
+          overflow,
+        }}
+      >
+        {loading && (
+          <canvas
+            className='image-loader__preview-canvas'
+            ref={setCanvasRef}
+            width={width}
+            height={height}
+          />
+        )}
         {!loading && (
           <img
-            alt={alt}
             className='image-loader__img'
+            role='presentation'
+            ref={setImageRef}
+            alt={alt}
             src={src}
             width={width}
             height={height}
+            style={{
+              transform: `scale(${scale})`,
+              transformOrigin: '0 0',
+            }}
+            onClick={this.handleClick}
           />
         )}
       </div>

--- a/app/javascript/mastodon/features/ui/components/image_loader.js
+++ b/app/javascript/mastodon/features/ui/components/image_loader.js
@@ -4,8 +4,6 @@ import classNames from 'classnames';
 
 const MIN_SCALE = 1;
 const MAX_SCALE = 4;
-const DOUBLE_TAP_SCALE = 2;
-const DOUBLE_TAP_THRESHOLD = 300; // ms
 
 const getMidpoint = (p1, p2) => ({
   x: (p1.clientX + p2.clientX) / 2,
@@ -62,7 +60,6 @@ export default class ImageLoader extends React.PureComponent {
     // on Chrome 56+, touch event listeners will default to passive
     // https://www.chromestatus.com/features/5093566007214080
     this.container.addEventListener('touchmove', this.handleTouchMove.bind(this), { passive: false });
-    this.container.addEventListener('touchend', this.handleTouchEnd.bind(this));
 
     this.loadImage(this.props);
   }
@@ -176,26 +173,9 @@ export default class ImageLoader extends React.PureComponent {
     this.lastDistance = distance;
   }
 
-  handleTouchEnd = ev => {
-    if (ev.touches.length > 0) return;
-    if (this.lastTouchEndTime && ev.timeStamp < this.lastTouchEndTime + DOUBLE_TAP_THRESHOLD) {
-      ev.preventDefault();
-      this.handleDoubleTap(ev);
-    }
-
-    this.lastTouchEndTime = ev.timeStamp;
-  }
-
   handleScroll = ev => {
     const handler = this.props.onScroll;
     if (handler) handler(ev);
-  }
-
-  handleDoubleTap (ev) {
-    if (this.state.scale === MIN_SCALE)
-      this.zoom(DOUBLE_TAP_SCALE, { x: ev.clientX, y: ev.clientY });
-    else
-      this.zoom(MIN_SCALE, { x: ev.clientX, y: ev.clientY });
   }
 
   zoom(nextScale, midpoint) {

--- a/app/javascript/mastodon/features/ui/components/image_loader.js
+++ b/app/javascript/mastodon/features/ui/components/image_loader.js
@@ -24,7 +24,6 @@ export default class ImageLoader extends React.PureComponent {
     width: PropTypes.number,
     height: PropTypes.number,
     onClick: PropTypes.func,
-    onScroll: PropTypes.func,
   }
 
   static defaultProps = {
@@ -171,11 +170,6 @@ export default class ImageLoader extends React.PureComponent {
 
     this.lastMidpoint = midpoint;
     this.lastDistance = distance;
-  }
-
-  handleScroll = ev => {
-    const handler = this.props.onScroll;
-    if (handler) handler(ev);
   }
 
   zoom(nextScale, midpoint) {

--- a/app/javascript/mastodon/features/ui/components/media_modal.js
+++ b/app/javascript/mastodon/features/ui/components/media_modal.js
@@ -126,7 +126,10 @@ export default class MediaModal extends ImmutablePureComponent {
         >
           <div className='media-modal__content'>
             <ReactSwipeableViews
-              style={{ height: '100%' }}
+              style={{
+                // on Android Chrome, pixel length of 100vh is mutable
+                height: `${document.body.clientHeight}px`,
+              }}
               containerStyle={containerStyle}
               onChangeIndex={this.handleSwipe}
               onSwitching={this.handleSwitching}

--- a/app/javascript/mastodon/features/ui/components/media_modal.js
+++ b/app/javascript/mastodon/features/ui/components/media_modal.js
@@ -72,7 +72,7 @@ export default class MediaModal extends ImmutablePureComponent {
 
   switchNavigation = () => {
     this.setState({
-      navigationShown: !this.navigationShown,
+      navigationShown: !this.state.navigationShown,
     });
   };
 

--- a/app/javascript/mastodon/features/ui/components/media_modal.js
+++ b/app/javascript/mastodon/features/ui/components/media_modal.js
@@ -2,11 +2,14 @@ import React from 'react';
 import ReactSwipeableViews from 'react-swipeable-views';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import ExtendedVideoPlayer from '../../../components/extended_video_player';
 import { defineMessages, injectIntl } from 'react-intl';
 import IconButton from '../../../components/icon_button';
 import ImmutablePureComponent from 'react-immutable-pure-component';
 import ImageLoader from './image_loader';
+
+const VERTICAL_SWIPE_THRESHOLD_RATIO = 0.3;
 
 const messages = defineMessages({
   close: { id: 'lightbox.close', defaultMessage: 'Close' },
@@ -26,10 +29,27 @@ export default class MediaModal extends ImmutablePureComponent {
 
   state = {
     index: null,
+    navigationShown: true,
+    swiping: false,
+    verticalSwipeDelta: 0,
   };
+
+  closer = null;
+  initialTouchPoint = null;
+  verticalSwipeThreshold = -1; // need to be smaller than 0
+  ignoreTouchMove = false;
 
   handleSwipe = (index) => {
     this.setState({ index: index % this.props.media.size });
+  }
+
+  handleSwitching = (i, s) => {
+    // disable vertical swiping while horizontally swiped
+    if (s === 'move') {
+      this.ignoreTouchMove = true;
+      this.setState({ verticalSwipeDelta: 0 });
+    }
+    if (s === 'end') this.ignoreTouchMove = false;
   }
 
   handleNextClick = () => {
@@ -56,8 +76,40 @@ export default class MediaModal extends ImmutablePureComponent {
     }
   }
 
+  handleTouchStart = ev => {
+    if (ev.touches.length !== 1) return;
+    this.initialTouchPoint = ev.touches[0];
+    this.setState({
+      swiping: true,
+      verticalSwipeDelta: 0,
+    });
+  }
+
+  handleTouchMove = ev => {
+    if (this.ignoreTouchMove) return;
+    if (ev.touches.length !== 1) return;
+    const p = ev.touches[0];
+    this.setState({
+      verticalSwipeDelta: p.clientY - this.initialTouchPoint.clientY,
+    });
+  }
+
+  handleTouchEnd = ev => {
+    if (ev.touches.length > 0) return;
+    if (this.state.verticalSwipeDelta <= this.verticalSwipeThreshold)
+      // FIXME モーダルが閉じるのに3秒くらいかかる
+      setTimeout(this.props.onClose, 300);
+    this.setState({ swiping: false });
+  }
+
   componentDidMount () {
+    this.verticalSwipeThreshold = -this.closer.clientHeight * VERTICAL_SWIPE_THRESHOLD_RATIO;
+
     window.addEventListener('keyup', this.handleKeyUp, false);
+
+    this.closer.addEventListener('touchstart', this.handleTouchStart.bind(this));
+    this.closer.addEventListener('touchmove', this.handleTouchMove.bind(this));
+    this.closer.addEventListener('touchend', this.handleTouchEnd.bind(this));
   }
 
   componentWillUnmount () {
@@ -70,12 +122,13 @@ export default class MediaModal extends ImmutablePureComponent {
 
   render () {
     const { media, intl, onClose } = this.props;
+    const { navigationShown, swiping, verticalSwipeDelta } = this.state;
 
     const index = this.getIndex();
     let pagination = [];
 
-    const leftNav  = media.size > 1 && <button tabIndex='0' className='modal-container__nav modal-container__nav--left' onClick={this.handlePrevClick} aria-label={intl.formatMessage(messages.previous)}><i className='fa fa-fw fa-chevron-left' /></button>;
-    const rightNav = media.size > 1 && <button tabIndex='0' className='modal-container__nav  modal-container__nav--right' onClick={this.handleNextClick} aria-label={intl.formatMessage(messages.next)}><i className='fa fa-fw fa-chevron-right' /></button>;
+    const leftNav  = media.size > 1 && <button tabIndex='0' className='media-modal__nav media-modal__nav--left' onClick={this.handlePrevClick} aria-label={intl.formatMessage(messages.previous)}><i className='fa fa-fw fa-chevron-left' /></button>;
+    const rightNav = media.size > 1 && <button tabIndex='0' className='media-modal__nav  media-modal__nav--right' onClick={this.handleNextClick} aria-label={intl.formatMessage(messages.next)}><i className='fa fa-fw fa-chevron-right' /></button>;
 
     if (media.size > 1) {
       pagination = media.map((item, i) => {
@@ -87,12 +140,18 @@ export default class MediaModal extends ImmutablePureComponent {
       });
     }
 
+    const switchNavigation = () => {
+      this.setState({
+        navigationShown: !navigationShown,
+      });
+    };
+
     const content = media.map((image) => {
       const width  = image.getIn(['meta', 'original', 'width']) || null;
       const height = image.getIn(['meta', 'original', 'height']) || null;
 
       if (image.get('type') === 'image') {
-        return <ImageLoader previewSrc={image.get('preview_url')} src={image.get('url')} width={width} height={height} alt={image.get('description')} key={image.get('url')} />;
+        return <ImageLoader previewSrc={image.get('preview_url')} src={image.get('url')} width={width} height={height} alt={image.get('description')} key={image.get('url')} onClick={switchNavigation} onScroll={this.cancelCloser} />;
       } else if (image.get('type') === 'gifv') {
         return <ExtendedVideoPlayer src={image.get('url')} muted controls={false} width={width} height={height} key={image.get('preview_url')} alt={image.get('description')} />;
       }
@@ -104,21 +163,55 @@ export default class MediaModal extends ImmutablePureComponent {
       alignItems: 'center', // center vertically
     };
 
+    const closerStyle = swiping ? {
+      transform: `translateY(${Math.min(verticalSwipeDelta, 0)}px)`,
+    } : {
+      transform: `translateY(${verticalSwipeDelta <= this.verticalSwipeThreshold ? '-100%' : '0'})`,
+      // FIXME better animation
+      transition: 'transform 0.3s linear',
+    };
+
+    const navigationClassName = classNames('media-modal__navigation', {
+      'media-modal__navigation--hidden': !navigationShown,
+    });
+
+    const setCloserRef = c => {
+      this.closer = c;
+    };
+
     return (
       <div className='modal-root__modal media-modal'>
-        {leftNav}
-
-        <div className='media-modal__content'>
-          <IconButton className='media-modal__close' title={intl.formatMessage(messages.close)} icon='times' onClick={onClose} size={16} />
-          <ReactSwipeableViews containerStyle={containerStyle} onChangeIndex={this.handleSwipe} index={index}>
-            {content}
-          </ReactSwipeableViews>
+        {/* FIXME onTouchXXX don't effect */}
+        <div
+          className='media-modal__closer'
+          role='presentation'
+          ref={setCloserRef}
+          style={closerStyle}
+          onClick={onClose}
+          onTouchStart={this.handleTouchStart}
+          onTouchMove={this.handleTouchMove}
+          onTouchEnd={this.handleTouchEnd}
+        >
+          <div className='media-modal__content'>
+            <ReactSwipeableViews
+              style={{ height: '100%' }}
+              containerStyle={containerStyle}
+              onChangeIndex={this.handleSwipe}
+              onSwitching={this.handleSwitching}
+              index={index}
+            >
+              {content}
+            </ReactSwipeableViews>
+          </div>
         </div>
-        <ul className='media-modal__pagination'>
-          {pagination}
-        </ul>
-
-        {rightNav}
+        <div className={navigationClassName}>
+          <IconButton className='media-modal__close' title={intl.formatMessage(messages.close)} icon='times' onClick={onClose} size={32} />
+          {leftNav}
+          {rightNav}
+          <ul className='media-modal__pagination'>
+            {pagination}
+          </ul>
+        </div>
       </div>
     );
   }

--- a/app/javascript/mastodon/features/ui/components/media_modal.js
+++ b/app/javascript/mastodon/features/ui/components/media_modal.js
@@ -137,7 +137,7 @@ export default class MediaModal extends ImmutablePureComponent {
           </div>
         </div>
         <div className={navigationClassName}>
-          <IconButton className='media-modal__close' title={intl.formatMessage(messages.close)} icon='times' onClick={onClose} size={32} />
+          <IconButton className='media-modal__close' title={intl.formatMessage(messages.close)} icon='times' onClick={onClose} size={40} />
           {leftNav}
           {rightNav}
           <ul className='media-modal__pagination'>

--- a/app/javascript/mastodon/features/ui/components/media_modal.js
+++ b/app/javascript/mastodon/features/ui/components/media_modal.js
@@ -101,7 +101,7 @@ export default class MediaModal extends ImmutablePureComponent {
       const height = image.getIn(['meta', 'original', 'height']) || null;
 
       if (image.get('type') === 'image') {
-        return <ImageLoader previewSrc={image.get('preview_url')} src={image.get('url')} width={width} height={height} alt={image.get('description')} key={image.get('url')} onClick={switchNavigation} onScroll={this.cancelCloser} />;
+        return <ImageLoader previewSrc={image.get('preview_url')} src={image.get('url')} width={width} height={height} alt={image.get('description')} key={image.get('url')} onClick={switchNavigation} />;
       } else if (image.get('type') === 'gifv') {
         return <ExtendedVideoPlayer src={image.get('url')} muted controls={false} width={width} height={height} key={image.get('preview_url')} alt={image.get('description')} />;
       }

--- a/app/javascript/mastodon/features/ui/components/media_modal.js
+++ b/app/javascript/mastodon/features/ui/components/media_modal.js
@@ -27,7 +27,7 @@ export default class MediaModal extends ImmutablePureComponent {
 
   state = {
     index: null,
-    navigationShown: true,
+    navigationHidden: false,
   };
 
   handleSwipe = (index) => {
@@ -70,15 +70,15 @@ export default class MediaModal extends ImmutablePureComponent {
     return this.state.index !== null ? this.state.index : this.props.index;
   }
 
-  switchNavigation = () => {
-    this.setState({
-      navigationShown: !this.state.navigationShown,
-    });
+  toggleNavigation = () => {
+    this.setState(prevState => ({
+      navigationHidden: !prevState.navigationHidden,
+    }));
   };
 
   render () {
     const { media, intl, onClose } = this.props;
-    const { navigationShown } = this.state;
+    const { navigationHidden } = this.state;
 
     const index = this.getIndex();
     let pagination = [];
@@ -109,7 +109,7 @@ export default class MediaModal extends ImmutablePureComponent {
             height={height}
             alt={image.get('description')}
             key={image.get('url')}
-            onClick={this.switchNavigation}
+            onClick={this.toggleNavigation}
           />
         );
       } else if (image.get('type') === 'gifv') {
@@ -122,7 +122,7 @@ export default class MediaModal extends ImmutablePureComponent {
             height={height}
             key={image.get('preview_url')}
             alt={image.get('description')}
-            onClick={this.switchNavigation}
+            onClick={this.toggleNavigation}
           />
         );
       }
@@ -135,7 +135,7 @@ export default class MediaModal extends ImmutablePureComponent {
     };
 
     const navigationClassName = classNames('media-modal__navigation', {
-      'media-modal__navigation--hidden': !navigationShown,
+      'media-modal__navigation--hidden': navigationHidden,
     });
 
     return (
@@ -148,7 +148,10 @@ export default class MediaModal extends ImmutablePureComponent {
           <div className='media-modal__content'>
             <ReactSwipeableViews
               style={{
-                // on Android Chrome, pixel length of 100vh is mutable
+                // you can't use 100vh, because the viewport height is taller
+                // than the visible part of the document in some mobile
+                // browsers when it's address bar is visible.
+                // https://developers.google.com/web/updates/2016/12/url-bar-resizing
                 height: `${document.body.clientHeight}px`,
               }}
               containerStyle={containerStyle}

--- a/app/javascript/mastodon/features/ui/components/media_modal.js
+++ b/app/javascript/mastodon/features/ui/components/media_modal.js
@@ -2,8 +2,8 @@ import React from 'react';
 import ReactSwipeableViews from 'react-swipeable-views';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 import ExtendedVideoPlayer from '../../../components/extended_video_player';
+import classNames from 'classnames';
 import { defineMessages, injectIntl } from 'react-intl';
 import IconButton from '../../../components/icon_button';
 import ImmutablePureComponent from 'react-immutable-pure-component';
@@ -103,7 +103,7 @@ export default class MediaModal extends ImmutablePureComponent {
       if (image.get('type') === 'image') {
         return <ImageLoader previewSrc={image.get('preview_url')} src={image.get('url')} width={width} height={height} alt={image.get('description')} key={image.get('url')} onClick={switchNavigation} />;
       } else if (image.get('type') === 'gifv') {
-        return <ExtendedVideoPlayer src={image.get('url')} muted controls={false} width={width} height={height} key={image.get('preview_url')} alt={image.get('description')} />;
+        return <ExtendedVideoPlayer src={image.get('url')} muted controls={false} width={width} height={height} key={image.get('preview_url')} alt={image.get('description')} onClick={switchNavigation}/>;
       }
 
       return null;

--- a/app/javascript/mastodon/features/ui/components/media_modal.js
+++ b/app/javascript/mastodon/features/ui/components/media_modal.js
@@ -70,6 +70,12 @@ export default class MediaModal extends ImmutablePureComponent {
     return this.state.index !== null ? this.state.index : this.props.index;
   }
 
+  switchNavigation = () => {
+    this.setState({
+      navigationShown: !this.navigationShown,
+    });
+  };
+
   render () {
     const { media, intl, onClose } = this.props;
     const { navigationShown } = this.state;
@@ -90,20 +96,35 @@ export default class MediaModal extends ImmutablePureComponent {
       });
     }
 
-    const switchNavigation = () => {
-      this.setState({
-        navigationShown: !navigationShown,
-      });
-    };
-
     const content = media.map((image) => {
       const width  = image.getIn(['meta', 'original', 'width']) || null;
       const height = image.getIn(['meta', 'original', 'height']) || null;
 
       if (image.get('type') === 'image') {
-        return <ImageLoader previewSrc={image.get('preview_url')} src={image.get('url')} width={width} height={height} alt={image.get('description')} key={image.get('url')} onClick={switchNavigation} />;
+        return (
+          <ImageLoader
+            previewSrc={image.get('preview_url')}
+            src={image.get('url')}
+            width={width}
+            height={height}
+            alt={image.get('description')}
+            key={image.get('url')}
+            onClick={this.switchNavigation}
+          />
+        );
       } else if (image.get('type') === 'gifv') {
-        return <ExtendedVideoPlayer src={image.get('url')} muted controls={false} width={width} height={height} key={image.get('preview_url')} alt={image.get('description')} onClick={switchNavigation}/>;
+        return (
+          <ExtendedVideoPlayer
+            src={image.get('url')}
+            muted
+            controls={false}
+            width={width}
+            height={height}
+            key={image.get('preview_url')}
+            alt={image.get('description')}
+            onClick={this.switchNavigation}
+          />
+        );
       }
 
       return null;

--- a/app/javascript/mastodon/features/ui/components/video_modal.js
+++ b/app/javascript/mastodon/features/ui/components/video_modal.js
@@ -16,7 +16,7 @@ export default class VideoModal extends ImmutablePureComponent {
     const { media, time, onClose } = this.props;
 
     return (
-      <div className='modal-root__modal media-modal'>
+      <div className='modal-root__modal video-modal'>
         <div>
           <Video
             preview={media.get('preview_url')}

--- a/app/javascript/mastodon/features/ui/components/zoomable_image.js
+++ b/app/javascript/mastodon/features/ui/components/zoomable_image.js
@@ -140,11 +140,7 @@ export default class ZoomableImage extends React.PureComponent {
       <div
         className='zoomable-image'
         ref={setContainerRef}
-        style={{
-          // on Android Chrome, pixel length of 100vh is mutable
-          height: `${document.body.clientHeight}px`,
-          overflow,
-        }}
+        style={{ overflow }}
       >
         <img
           role='presentation'

--- a/app/javascript/mastodon/features/ui/components/zoomable_image.js
+++ b/app/javascript/mastodon/features/ui/components/zoomable_image.js
@@ -89,11 +89,6 @@ export default class ZoomableImage extends React.PureComponent {
     this.lastDistance = distance;
   }
 
-  handleScroll = ev => {
-    const handler = this.props.onScroll;
-    if (handler) handler(ev);
-  }
-
   zoom(nextScale, midpoint) {
     const { scale } = this.state;
     const { scrollLeft, scrollTop } = this.container;
@@ -124,27 +119,28 @@ export default class ZoomableImage extends React.PureComponent {
     if (handler) handler();
   }
 
+  setContainerRef = c => {
+    this.container = c;
+  }
+
+  setImageRef = c => {
+    this.image = c;
+  }
+
   render () {
     const { alt, src } = this.props;
     const { scale } = this.state;
     const overflow = scale === 1 ? 'hidden' : 'scroll';
 
-    const setContainerRef = c => {
-      this.container = c;
-    };
-    const setImageRef = c => {
-      this.image = c;
-    };
-
     return (
       <div
         className='zoomable-image'
-        ref={setContainerRef}
+        ref={this.setContainerRef}
         style={{ overflow }}
       >
         <img
           role='presentation'
-          ref={setImageRef}
+          ref={this.setImageRef}
           alt={alt}
           src={src}
           style={{

--- a/app/javascript/mastodon/features/ui/components/zoomable_image.js
+++ b/app/javascript/mastodon/features/ui/components/zoomable_image.js
@@ -1,0 +1,164 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const MIN_SCALE = 1;
+const MAX_SCALE = 4;
+
+const getMidpoint = (p1, p2) => ({
+  x: (p1.clientX + p2.clientX) / 2,
+  y: (p1.clientY + p2.clientY) / 2,
+});
+
+const getDistance = (p1, p2) =>
+  Math.sqrt(Math.pow(p1.clientX - p2.clientX, 2) + Math.pow(p1.clientY - p2.clientY, 2));
+
+const between = (min, max, value) => Math.min(max, Math.max(min, value));
+
+export default class ZoomableImage extends React.PureComponent {
+
+  static propTypes = {
+    alt: PropTypes.string,
+    src: PropTypes.string.isRequired,
+    width: PropTypes.number,
+    height: PropTypes.number,
+    onClick: PropTypes.func,
+  }
+
+  static defaultProps = {
+    alt: '',
+    width: null,
+    height: null,
+  };
+
+  state = {
+    scale: MIN_SCALE,
+  }
+
+  removers = [];
+  container = null;
+  image = null;
+  lastTouchEndTime = 0;
+  lastDistance = 0;
+
+  componentDidMount () {
+    let handler = this.handleTouchStart.bind(this);
+    this.container.addEventListener('touchstart', handler);
+    this.removers.push(() => this.container.removeEventListener('touchstart', handler));
+    handler = this.handleTouchMove.bind(this);
+    // on Chrome 56+, touch event listeners will default to passive
+    // https://www.chromestatus.com/features/5093566007214080
+    this.container.addEventListener('touchmove', handler, { passive: false });
+    this.removers.push(() => this.container.removeEventListener('touchend', handler));
+  }
+
+  componentWillUnmount () {
+    this.removeEventListeners();
+  }
+
+  removeEventListeners () {
+    this.removers.forEach(listeners => listeners());
+    this.removers = [];
+  }
+
+  handleTouchStart = ev => {
+    if (ev.touches.length !== 2) return;
+
+    this.lastDistance = getDistance(...ev.touches);
+  }
+
+  handleTouchMove = ev => {
+    const { scrollTop, scrollHeight, clientHeight } = this.container;
+    if (ev.touches.length === 1
+      && scrollTop !== scrollHeight - clientHeight) {
+      // prevent propagating event to MediaModal
+      ev.stopPropagation();
+      return;
+    }
+    if (ev.touches.length !== 2) return;
+
+    ev.preventDefault();
+    ev.stopPropagation();
+
+    const distance = getDistance(...ev.touches);
+    const midpoint = getMidpoint(...ev.touches);
+    const scale = between(MIN_SCALE, MAX_SCALE, this.state.scale * distance / this.lastDistance);
+
+    this.zoom(scale, midpoint);
+
+    this.lastMidpoint = midpoint;
+    this.lastDistance = distance;
+  }
+
+  handleScroll = ev => {
+    const handler = this.props.onScroll;
+    if (handler) handler(ev);
+  }
+
+  zoom(nextScale, midpoint) {
+    const { scale } = this.state;
+    const { scrollLeft, scrollTop } = this.container;
+
+    // math memo:
+    // x = (scrollLeft + midpoint.x) / scrollWidth
+    // x' = (nextScrollLeft + midpoint.x) / nextScrollWidth
+    // scrollWidth = clientWidth * scale
+    // scrollWidth' = clientWidth * nextScale
+    // Solve x = x' for nextScrollLeft
+    const nextScrollLeft = (scrollLeft + midpoint.x) * nextScale / scale - midpoint.x;
+    const nextScrollTop = (scrollTop + midpoint.y) * nextScale / scale - midpoint.y;
+
+    // this.container.scrollLeft = nextScrollLeft;
+    // this.container.scrollTop = nextScrollTop;
+
+    this.setState({ scale: nextScale }, () => {
+      // callback
+      this.container.scrollLeft = nextScrollLeft;
+      this.container.scrollTop = nextScrollTop;
+    });
+  }
+
+  handleClick = ev => {
+    // don't propagate event to MediaModal
+    ev.stopPropagation();
+    const handler = this.props.onClick;
+    if (handler) handler();
+  }
+
+  render () {
+    const { alt, src } = this.props;
+    const { scale } = this.state;
+    const overflow = scale === 1 ? 'hidden' : 'scroll';
+
+    const setContainerRef = c => {
+      this.container = c;
+    };
+    const setImageRef = c => {
+      this.image = c;
+    };
+
+    return (
+      <div
+        className='zoomable-image'
+        ref={setContainerRef}
+        style={{
+          // on Android Chrome, pixel length of 100vh is mutable
+          height: `${document.body.clientHeight}px`,
+          overflow,
+        }}
+      >
+        <img
+          role='presentation'
+          ref={setImageRef}
+          alt={alt}
+          src={src}
+          style={{
+            transform: `scale(${scale})`,
+            transformOrigin: '0 0',
+          }}
+          onClick={this.handleClick}
+        />
+      </div>
+    );
+  }
+
+}

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1375,12 +1375,14 @@
 }
 
 .image-loader {
-  position: relative;
-  width: 100vw;
-  display: flex;
-  align-content: center;
 
   &.image-loader--loading {
+    position: relative;
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    align-content: center;
+
     .image-loader__preview-canvas {
       filter: blur(2px);
     }
@@ -1392,13 +1394,14 @@
     .image-loader__preview-canvas {
       display: none;
     }
-
-    .image-loader__img {
-      position: static;
-      width: auto;
-      height: auto;
-    }
   }
+}
+
+.zoomable-image {
+  position: relative;
+  width: 100vw;
+  display: flex;
+  align-content: center;
 }
 
 .navigation-bar {

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3331,12 +3331,17 @@ a.status-card {
   z-index: 9999;
 }
 
+.video-modal {
+  max-width: 100vw;
+  max-height: 100vh;
+  position: relative;
+}
+
 .media-modal {
   width: 100%;
   height: 100%;
   position: relative;
 
-  .extended-video-player,
   img,
   canvas,
   video {
@@ -3345,13 +3350,6 @@ a.status-card {
     width: auto;
     height: auto;
     margin: auto;
-  }
-
-  .extended-video-player,
-  video {
-    display: flex;
-    width: 100vw;
-    height: 100vh;
   }
 
   img,

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -3453,10 +3453,9 @@ a.status-card {
 
 .media-modal__close {
   position: absolute;
-  right: 4px;
-  top: 4px;
+  right: 8px;
+  top: 8px;
   z-index: 100;
-  padding: 8px;
 }
 
 .onboarding-modal,

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1375,11 +1375,11 @@
 }
 
 .image-loader {
+  position: relative;
+  width: 100%;
+  height: 100%;
 
   &.image-loader--loading {
-    position: relative;
-    width: 100vw;
-    height: 100vh;
     display: flex;
     align-content: center;
 
@@ -1388,18 +1388,15 @@
     }
   }
 
-  &.image-loader--amorphous {
-    position: static;
-
-    .image-loader__preview-canvas {
-      display: none;
-    }
+  &.image-loader--amorphous .image-loader__preview-canvas {
+    display: none;
   }
 }
 
 .zoomable-image {
   position: relative;
-  width: 100vw;
+  width: 100%;
+  height: 100%;
   display: flex;
   align-content: center;
 }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1376,21 +1376,14 @@
 
 .image-loader {
   position: relative;
+  width: 100vw;
+  display: flex;
+  align-content: center;
 
   &.image-loader--loading {
     .image-loader__preview-canvas {
       filter: blur(2px);
     }
-  }
-
-  .image-loader__img {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    max-width: 100%;
-    max-height: 100%;
-    background-image: none;
   }
 
   &.image-loader--amorphous {
@@ -2739,29 +2732,6 @@ a.status-card {
   }
 }
 
-.modal-container__nav {
-  align-items: center;
-  background: rgba($base-overlay-background, 0.5);
-  box-sizing: border-box;
-  border: 0;
-  color: $primary-text-color;
-  cursor: pointer;
-  display: flex;
-  font-size: 24px;
-  height: 100%;
-  padding: 30px 15px;
-  position: absolute;
-  top: 0;
-}
-
-.modal-container__nav--left {
-  left: -61px;
-}
-
-.modal-container__nav--right {
-  right: -61px;
-}
-
 .account--follows-info {
   color: $primary-text-color;
   position: absolute;
@@ -3359,16 +3329,16 @@ a.status-card {
 }
 
 .media-modal {
-  max-width: 80vw;
-  max-height: 80vh;
+  width: 100%;
+  height: 100%;
   position: relative;
 
   .extended-video-player,
   img,
   canvas,
   video {
-    max-width: 80vw;
-    max-height: 80vh;
+    max-width: 100vw;
+    max-height: 100vh;
     width: auto;
     height: auto;
     margin: auto;
@@ -3377,8 +3347,8 @@ a.status-card {
   .extended-video-player,
   video {
     display: flex;
-    width: 80vw;
-    height: 80vh;
+    width: 100vw;
+    height: 100vh;
   }
 
   img,
@@ -3389,12 +3359,65 @@ a.status-card {
   }
 
   .react-swipeable-view-container {
-    max-width: 80vw;
+    width: 100vw;
+    height: 100%;
   }
 }
 
-.media-modal__content {
-  background: $base-overlay-background;
+.media-modal__closer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+
+.media-modal__navigation {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+  transition: opacity 0.3s linear;
+  will-change: opacity;
+
+  * {
+    pointer-events: auto;
+  }
+
+  &.media-modal__navigation--hidden {
+    opacity: 0;
+
+    * {
+      pointer-events: none;
+    }
+  }
+}
+
+.media-modal__nav {
+  background: rgba($base-overlay-background, 0.5);
+  box-sizing: border-box;
+  border: 0;
+  color: $primary-text-color;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  font-size: 24px;
+  height: 20vmax;
+  margin: auto 0;
+  padding: 30px 15px;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+}
+
+.media-modal__nav--left {
+  left: 0;
+}
+
+.media-modal__nav--right {
+  right: 0;
 }
 
 .media-modal__pagination {
@@ -3402,7 +3425,8 @@ a.status-card {
   text-align: center;
   position: absolute;
   left: 0;
-  bottom: -40px;
+  bottom: 20px;
+  pointer-events: none;
 }
 
 .media-modal__page-dot {
@@ -3429,6 +3453,7 @@ a.status-card {
   right: 4px;
   top: 4px;
   z-index: 100;
+  padding: 8px;
 }
 
 .onboarding-modal,


### PR DESCRIPTION
This pr is mainly for mobile devices.

- Pinch zoom and pan
- Larger image
- Larger close button (Solves # 3660, # 4743)
- Close the modal by swiping vertically (suggested in # 4743)
- Show/hide close button and right/left navigation on tapping image
- More blank space to close the modal
- Zoom/reset zoom on double tap

before:
![Screenshot of before](https://user-images.githubusercontent.com/574575/33802009-7cb21148-ddb0-11e7-8505-6d2fc976ea95.png)

after:
![Screenshot of after](https://user-images.githubusercontent.com/574575/33802035-f7c5f034-ddb0-11e7-894a-28af2b6dbd9e.png)

screencast (click to open YouTube):
[![YouTube thumbnail](https://user-images.githubusercontent.com/574575/33802486-a2a7bfc8-ddbb-11e7-904d-28eebf407d6d.png)](https://youtu.be/xJoJi8rAAwQ)

# TODOs (help and advice wanted!)
- [ ] What the name of `ImageLoader` should be?
- [ ] What is `--amorphous` state of the image?
- [ ] Can't zoom on the tapping point on double tap
- [ ] Got extra margin on the bottom of the modal (I can't find out why this happens).
- [ ] The modal closes after some seconds delay from swiping.
- [ ] What is the proper value of `VERTICAL_SWIPE_THRESHOLD_RATIO` ?
- [ ] Better animation for vertical swiping
- [ ] Not tested for video player
- [ ] Adjust margin of close button
- [ ] What is the proper value of `MAX_SCALE` and `DOUBLE_TAP_SCALE` ?
- [ ] Not tested on iOS.

“cat” by waferboard is licensed under CC BY 2.0
“The Black Cat / Черная кошка” by Julay Cat is licensed under CC BY 2.0